### PR TITLE
docs: fix wrong example path in README

### DIFF
--- a/nacos/README.md
+++ b/nacos/README.md
@@ -91,13 +91,13 @@ make prepare
 ### run server
 
 ```go
-go run ./example/standard/server/main.go
+go run ./examples/standard/server/main.go
 ```
 
 ### run client
 
 ```go
-go run ./example/standard/client/main.go
+go run ./examples/standard/client/main.go
 ```
 
 ```go

--- a/nacos/README_CN.md
+++ b/nacos/README_CN.md
@@ -89,13 +89,13 @@ make prepare
 ### run server
 
 ```go
-go run ./example/standard/server/main.go
+go run ./examples/standard/server/main.go
 ```
 
 ### run client
 
 ```go
-go run ./example/standard/client/main.go
+go run ./examples/standard/client/main.go
 ```
 
 ```bash


### PR DESCRIPTION
#### What type of PR is this?

docs
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: wrong path in README
